### PR TITLE
Load resources over HTTPS

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 var dataUrl = 'data/data.csv';
 var maxZoom = 16;
 var fieldSeparator = ',';
-var baseUrl = 'http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg';
+var baseUrl = '//otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg';
 var baseAttribution = 'Data, imagery and map information provided by <a href="http://open.mapquest.co.uk" target="_blank">MapQuest</a>, <a href="http://www.openstreetmap.org/" target="_blank">OpenStreetMap</a> and contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank">CC-BY-SA</a>';
 var subdomains = '1234';
 var clusterOptions = {showCoverageOnHover: false, maxClusterRadius: 50};

--- a/index.html
+++ b/index.html
@@ -5,28 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="http-equiv" content="Content-type: text/html; charset=UTF-8"/>
 
-    <link rel="stylesheet" href="http://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/0.7.3/leaflet.css" />
-    <link rel="stylesheet" href="http://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="http://tools-static.wmflabs.org/cdnjs/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css" />
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/0.7.3/leaflet.css" />
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css" />
     <link rel="stylesheet" href="css/MarkerCluster.css" />
     <link rel="stylesheet" href="css/MarkerCluster.Default.css" />
     <link rel="stylesheet" href="css/leaflet.label.css" />
     <link rel="stylesheet" href="css/easy-button.css" />
-    <link rel="stylesheet" href="http://tools-static.wmflabs.org/cdnjs/ajax/libs/pace/1.0.2/themes/blue/pace-theme-center-simple.css" />
-    <link rel="stylesheet" href="http://tools-static.wmflabs.org/cdnjs/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css" />
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/pace/1.0.2/themes/blue/pace-theme-center-simple.css" />
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css" />
     <link rel="stylesheet" href="css/screen.css" />
 </head>
 <body>
 
     <div id="map"></div>
 
-    <script src="http://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script src="http://tools-static.wmflabs.org/cdnjs/ajax/libs/pace/1.0.2/pace.min.js"></script>
-    <script src="http://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js"></script>
-    <script src="http://tools-static.wmflabs.org/cdnjs/ajax/libs/bootbox.js/4.4.0/bootbox.min.js"></script>
-    <script src="http://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
-    <script src="http://tools-static.wmflabs.org/cdnjs/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <script src="http://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/pace/1.0.2/pace.min.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/bootbox.js/4.4.0/bootbox.min.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>
     <script src="js/leaflet.geocsv.js"></script>
     <script src="js/leaflet.label.js"></script>
     <script src="js/easy-button.js"></script>


### PR DESCRIPTION
Browsers refuse to load unsecure resources in HTTPS pages.
mqcdn.com is not available over HTTPS (Akamai servers with non-Akamai
certificate) but at least the HTTPS user will see a warning rather than
silently see the resources dropped by the browser.