### PR TITLE
Add toolinfo.json metadata file

### DIFF
--- a/toolinfo.json
+++ b/toolinfo.json
@@ -1,0 +1,11 @@
+[
+    {
+      "name" : "wiki-needs-pictures",
+      "title" : "Wiki Needs Pictures",
+      "description" : "Map showing entities around the world that need photographs on Wikipedia.",
+      "url" : "https://tools.wmflabs.org/wiki-needs-pictures/",
+      "keywords" : "Wikipedia, map, Commons, illustration, picture, photograph, image, around, coordinate",
+      "author" : "Alessio",
+      "repository" : "https://github.com/alemela/wiki-needs-pictures"
+    }
+]


### PR DESCRIPTION
Hello,

I noticed this tools is not discoverable via [Hay’s Tools Directory](http://tools.wmflabs.org/hay/directory/), that I believe many users rely on to navigate the myriad of cool tools on ToolLabs

Here is a PR for a `toolinfo.json` file. I added it to the root folder based on my understanding of the layout − happy to change that if needed.
